### PR TITLE
Removed space from NottsJS title

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
                     </li>
                     <li class="event vcard" data-theme="tech" >
                         <div class="event__theme event__theme--tech"><img class="icon" src="./img/tech.svg" alt="Tech"></div>
-                        <h3 class="event__title"><a class="fn org url" href="https://nottsjs.org/">Notts JS</a> <a class="twitter" href="https://twitter.com/nottsjs"><img class="icon" src="./img/twitter.svg" alt="Twitter"></a></h3>
+                        <h3 class="event__title"><a class="fn org url" href="https://nottsjs.org/">NottsJS</a> <a class="twitter" href="https://twitter.com/nottsjs"><img class="icon" src="./img/twitter.svg" alt="Twitter"></a></h3>
                         <p class="event__summary who">A meetup for developers and anyone else interested in Node, JavaScript and Full Stack development.</p>
                         <p class="event__date when"><img class="icon" src="./img/event.svg" alt="Next Event"> Second Tuesday</p>
                     </li>


### PR DESCRIPTION
It's nitpicky, I know 🙂 