### PR TITLE
Update Homebrew Website Club Nottingham URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,7 +228,7 @@
                     </li>
                     <li class="event vcard" data-theme="tech" >
                         <div class="event__theme event__theme--tech"><img class="icon" src="./img/tech.svg" alt="Tech"></div>
-                        <h3 class="event__title"><a class="fn org url" href="https://www.jvt.me/events/homebrew-website-club-nottingham/">Homebrew Website Club</a></h3>
+                        <h3 class="event__title"><a class="fn org url" href="https://events.indieweb.org/tag/hwc-nottingham">Homebrew Website Club</a></h3>
                         <p class="event__summary who">The Homebrew Website Club is a regular meeting for enthusiasts and hobbyist programmers who are building, or thinking of building, their personal websites. The meeting is an informal setting where you can talk with others, get inspiration, or quietly work on your site.</p>
                         <p class="event__date when"><img class="icon" src="./img/event.svg" alt="Next Event"> First and third Wednesdays</p>
                     </li>


### PR DESCRIPTION
As mentioned [in my post][0], events will no longer be on my URL, but the
IndieWeb Events site.

[0]: https://www.jvt.me/posts/2020/01/11/homebrew-website-club-nottingham-url/